### PR TITLE
Improve JVM arguments

### DIFF
--- a/FreeOP Servers/.env.sh
+++ b/FreeOP Servers/.env.sh
@@ -16,4 +16,4 @@ RESET_FILE="/home/tfserver/.resetting"
 #JVM_LAUNCH_OPTS="-XX:+CMSClassUnloadingEnabled -XX:ParallelGCThreads=2 -XX:MinHeapFreeRatio=5 -XX:MaxHeapFreeRatio=10"
 
 #Java 16 Launch Opts
-JVM_LAUNCH_OPTS="--illegal-access=permit -XX:ParallelGCThreads=2 -XX:MinHeapFreeRatio=5 -XX:MaxHeapFreeRatio=10"
+JVM_LAUNCH_OPTS="--illegal-access=permit -XX:+UseZGC -XX:+DisableExplicitGC"


### PR DESCRIPTION
A little explanation of each flag:

Removed:
`-XX:ParallelGCThreads=2` -- Totally redundant as Java 9 makes the G1GC garbage collector default. This only applies to the Parallel GC.
`-XX:MinHeapFreeRatio` and `-XX:MaxHeapFreeRatio` -- These flags strain the JVM heap and are only useful in very niche scenarios. Also the majority of info on these two flags are from the early 2010s.

Added:
`-XX:+UseZGC` -- The ZGC garbage collector has been deemed stable by Oracle and provides faster and more stable memory management.
`-XX:+DisableExplicitGC` -- This flag forcefully disables the manual garbage collection calls available in the Java library, such as `System.gc()`. Many programmers think they know better than the JVM and use this which ultimately ends up harming performance. This disables the calls globally, ensuring that the garbage collector can do its job when it needs to.

Ultimately, it's better to keep it simple when it comes to flags and to avoid using obscure flags from 2013. The JVM developers know it better than most.